### PR TITLE
Include readme.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include license.md
+include readme.md


### PR DESCRIPTION
This would include readme.md in the sdist; which would prevent possible downstream build errors (e.g. on conda-forge)